### PR TITLE
update sponsor url (again)

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ slug: home
   <a href="https://opencollective.com/sustainoss/events/2017">
     Buy Tickets
   </a>
-  <a href="https://opencollective.com/sustainoss/donate/1000/Thank%20you%20for%20your%20contribution%20to%20the%20travel%20&%20accomodation%20fund!">
+  <a href="https://opencollective.com/sustainoss/events/2017#sponsor">
     Support Us
   </a>
 </div>


### PR DESCRIPTION
we are moving them back to the tickets page, anchored to the 'sponsors' support button. We made it clearer, they'll show up as sponsors.