### PR TITLE
Bring back max-width on inside pages

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -163,7 +163,7 @@ a {
 
 .inside-page-content {
   text-align: left;
-  /*max-width: 55rem;*/
+  max-width: 55rem;
   margin: 0 auto;
   padding: 8vw;
 }

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -334,6 +334,9 @@ a {
   }
 
   .page-sponsor {
+    .inside-page-content {
+      max-width: none; /* moar logos! */
+    }
     .sponsor-form {
       height: 900px;
     }

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -325,7 +325,7 @@ a {
     margin: 0 auto 102.4px;
   }
   .inside-page-content {
-    max-width: 538px; /* 576 - 51.2 - 51.2 */
+    max-width: 538px;
     padding: 51.2px 0;
   }
 

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -163,7 +163,6 @@ a {
 
 .inside-page-content {
   text-align: left;
-  max-width: 55rem;
   margin: 0 auto;
   padding: 8vw;
 }
@@ -326,6 +325,7 @@ a {
     margin: 0 auto 102.4px;
   }
   .inside-page-content {
+    max-width: 538px; /* 576 - 51.2 - 51.2 */
     padding: 51.2px 0;
   }
 


### PR DESCRIPTION
Not sure why we turned this off. Without it, the content is way too wide on inside pages on wide screens, leading to subpar results such as:

![screen shot 2017-03-28 at 10 04 23 am](https://cloud.githubusercontent.com/assets/134455/24409338/f0b47636-139d-11e7-8974-c89049b8fcf4.png)