### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ exclude:
 
 params:
   github:           "https://github.com/sustainers"
-  slack:            "https://changelog.slack.com/"
+  slack:            "https://changelog.com/community"
   twitter:          "https://twitter.com/SustainOSS"
   latitude:         51.5286903
   longitude:        -0.1301617


### PR DESCRIPTION
Better to link to [the community page](https://changelog.com/community) vs Slack signin. The community page will actually let them signup for Slack vs where this link goes which is strictly signin only.