### PR TITLE
Governance Readiness WG webpage https fix

### DIFF
--- a/working-groups/governance-readiness.md
+++ b/working-groups/governance-readiness.md
@@ -6,7 +6,7 @@ slug: governance-readiness
 
 **Status**: Active<br>
 **Bottom liner**: [Javier Cánovas](https://twitter.com/jlcanovas)<br>
-**How to get involved**: Feel free to contact [Javier Cánovas](http://jlcanovas.es/) or introduce yourself [in the Discourse discussion thread](https://discourse.sustainoss.org/t/governance-readiness-working-group/298)
+**How to get involved**: Feel free to contact [Javier Cánovas](https://jlcanovas.es/) or introduce yourself [in the Discourse discussion thread](https://discourse.sustainoss.org/t/governance-readiness-working-group/298)
 
 ## Purpose
 
@@ -50,4 +50,4 @@ The working group has just been created. We are still in the process of identify
 
 We plan to have the first online meeting in mid-April, feel free to attend. The main content we plan to discuss is summarized in the [report](https://docs.google.com/document/d/1A2SsCeigKU-8JC2wJS8hXuxcB2tV5XnOj94JmxvPzfw). We will publish the doodle to set the final date soon.
 
-You can contact [Javier Cánovas](http://jlcanovas.es/) to be included in the loop.
+You can contact [Javier Cánovas](https://jlcanovas.es/) to be included in the loop.


### PR DESCRIPTION
This PR refers to #255. As [promised](https://github.com/sustainers/website/pull/255#issuecomment-605912158), all links are now https (enabled at jlcanovas.es, kudos to GitHub 😄) 

the `html-proofer` check can be added again.