### PR TITLE
Updating the Governance Readiness WG (conclusion)

### DIFF
--- a/working-groups/governance-readiness.md
+++ b/working-groups/governance-readiness.md
@@ -4,9 +4,9 @@ title: Governance Readiness
 slug: governance-readiness
 ---
 
-**Status**: Active<br>
+**Status**: Concluded<br>
 **Bottom liner**: [Javier Cánovas](https://twitter.com/jlcanovas)<br>
-**How to get involved**: Feel free to contact [Javier Cánovas](https://jlcanovas.es/) or introduce yourself [in the Discourse discussion thread](https://discourse.sustainoss.org/t/governance-readiness-working-group/298)
+**Further details**: This working group has concluded. You can view details about it [in the Discourse discussion thread](https://discourse.sustainoss.org/t/governance-readiness-working-group/298)
 
 ## Purpose
 
@@ -35,19 +35,33 @@ Other complementary goals are:
 
 ## Reports and documents
 
-The first discussion took place at Sustain 2020.
+The first discussion took place at Sustain 2020:
 
 * [Notes of the session](https://docs.google.com/document/d/14xpOea_P8FZlcuppzqzwLqXyr4pgyddpBXXwlaHOH8c)
 * [Summary of the session and report for kick-off meeting](https://docs.google.com/document/d/1A2SsCeigKU-8JC2wJS8hXuxcB2tV5XnOj94JmxvPzfw)
+* [Organization of the group](https://discourse.sustainoss.org/t/governance-readiness-working-group/298?u=jlcanovas)
+
+April, 14th, 2020. Kick-off meeting:
+* [Agenda](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/8?u=jlcanovas)
+* [Notes of the session](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/9?u=jlcanovas)
+
+April, 27th, 2020. Milestone 1:
+* [Update](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/12?u=jlcanovas)
+
+May, 6th, 2020. Milestone 2:
+* [Update](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/14?u=jlcanovas)
+
+June 4th, 2020. Second meeting:
+* [Agenda](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/24?u=jlcanovas)
+* [Notes of the session](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/29?u=jlcanovas)
+
+July, 7th, 2020. Milestone 3:
+* [Update](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/41?u=jlcanovas)
+
+July, 28th, 2020. Last Update:
+* [Update](https://discourse.sustainoss.org/t/governance-readiness-working-group/298/50?u=jlcanovas)
 
 ## Resources
 
 * [Resources folder](https://drive.google.com/drive/folders/1u-EQqgxIQ9xkaA8ge7oROBqk7Vb4hU_y)
 
-## How to get involved
-
-The working group has just been created. We are still in the process of identifying the actual outcome of the group. Feel free to join and share your view on this topic. Any feedback is welcome.
-
-We plan to have the first online meeting in mid-April, feel free to attend. The main content we plan to discuss is summarized in the [report](https://docs.google.com/document/d/1A2SsCeigKU-8JC2wJS8hXuxcB2tV5XnOj94JmxvPzfw). We will publish the doodle to set the final date soon.
-
-You can contact [Javier Cánovas](https://jlcanovas.es/) to be included in the loop.

--- a/working-groups/governance-readiness.md
+++ b/working-groups/governance-readiness.md
@@ -18,6 +18,8 @@ The main goal of the working group has initially been described as:
 
 * Create a checklist to verify whether open source projects _are ready_ to deploy some kind of governance (or to change their current governance for a healthy one).
 
+You can visit the checklist website [here](https://sustainers.github.io/governance-readiness/).
+
 Other complementary goals are:
 
 * Identification of analysis dimensions in open source projects. It may be needed for the assessment of the current status of the project.


### PR DESCRIPTION
This PR updates the Governance Readinesss WG webpage at SustainOSS website. It explicitly says that the WG has concluded and lists the resources created.