### PR TITLE
Creating new Working Group about Governance Guidance

### DIFF
--- a/_data/wgs.yml
+++ b/_data/wgs.yml
@@ -100,7 +100,7 @@
 - title: Community Principles & Ostrom Redux
   bottomliner: Greg Bloom
   slug: ostrom
-  status: Active
+  status: Concluded
   ranking: 2
   url: true
   description: "Elinor Ostrom laid out principles of healthy communities for governing the commons. How can we apply her Nobel-prize winning research to the world of open source?"
@@ -108,7 +108,7 @@
 - title: Governance Readiness
   bottomliner: Javier Cánovas
   slug: governance-readiness
-  status: Active
+  status: Concluded
   url: true
   ranking: 2
   description: "What does healhty governance look like? How can we improve our day-to-day work, identify barriers and needs, and intervene where new governance structures are needed?"
@@ -159,4 +159,12 @@
   ranking: 2
   url: true
   description: "How can the Open Source ecosystem respond to Covid-19? How can we help developers who are losing money, jobs, and conferences?"
+
+- title: Governance Guidance
+  bottomliner: Javier Cánovas, Greg Bloom
+  slug: governance-guidance
+  status: Active
+  ranking: 2
+  url: true
+  description: "How can we guide developers to create efficient governance models?"
 

--- a/working-groups/governance-guidance.md
+++ b/working-groups/governance-guidance.md
@@ -1,0 +1,36 @@
+---
+layout: text-page
+title: Governance Guidance
+slug: governance-guidance
+---
+
+**Status**: Active<br>
+**Bottom liner**: [Javier Cánovas](https://twitter.com/jlcanovas) and [Greg Bloom](mailto:bloom@gregbloom.org)<br>
+**How to get involved**: Get in touch with Javi or Greg 
+
+## Purpose
+
+To create resources to facilitate the elicitation of governance models in Open Source projects.
+
+## Goals
+
+Our goals include the elaboration on principles on governance, the definition of a matrix of questions to ask frequently (joining ideas from previous WGs), etc.
+
+## Guiding questions
+
+* How can we guide developers to create efficient governance models?
+* Which principles drive the definition of governance models in your project?
+* Which dimensions should you consider when elicitating governance models?
+* How can you efficiently address governance in recently created projects?
+
+## Reports and documents
+
+You will find the reports and documents in this section.
+
+## Resources
+
+Other resources will be included here.
+
+## How to get involved
+
+Just drop an email to [Javier Cánovas](https://twitter.com/jlcanovas) and/or [Greg Bloom](mailto:bloom@gregbloom.org)


### PR DESCRIPTION
Creating a new Working Group for collecting the efforts on governance.

This PR:
* Creates a new Working Group called Governance Guidance
* Sets as _concluded_ the Working Groups called Governance Readiness and Community Principles & Ostrom Redux