### PR TITLE
Add Sustain Workshop Funding Application to website

### DIFF
--- a/_posts/SustainOSS-Organizing-Committee.md
+++ b/_posts/SustainOSS-Organizing-Committee.md
@@ -1,0 +1,18 @@
+# SustainOSS Organizing Committee – Sustain Workshops and Funding Applications
+## Purpose:
+
+This document recognizes that current fund applications for workshops at Sustain are organized through exclusive, private networks connected to the Sustain organizer committee. By outlining, publicizing, and sharing this process, we hope to make a more inclusive community. 
+
+
+## Proposal:
+
+
+The [SustainOSS](https://sustainoss.org/about/) (henceforth Sustain) organizing committee meets every couple of weeks to discuss organizational matters. Part of this involves planning for the next **Sustain Summit - most likely, as of this writing, in March 2023.** 
+
+The Sustain Summit is normally a one-day event which is held at a single venue, normally in a single room, with occasional breakout rooms as part of that process. Funds go towards photographers, catering, venue costs, comms, and travel expenses for bursaries. Funds can also go towards individual projects hosted at the session, and to their individual needs; they can also go towards ancillary events at Sustain, like workshops, which focus on some more specific aspect of software sustainability. 
+
+## Application details: 
+In order to propose that SustainOSS funds are used for your workshop, we encourage you to use the following [form](https://forms.gle/Q9LsQwwD7tuk1hz16), which goes to the Sustain organizing committee. We promise to have a one-month response time for all submissions.
+
+The funds available have neither a lower nor an upper limit. All submissions are considered anonymously. 
+

--- a/_posts/SustainOSS-Organizing-Committee.md
+++ b/_posts/SustainOSS-Organizing-Committee.md
@@ -15,4 +15,3 @@ The Sustain Summit is normally a one-day event which is held at a single venue, 
 In order to propose that SustainOSS funds are used for your workshop, we encourage you to use the following [form](https://forms.gle/Q9LsQwwD7tuk1hz16), which goes to the Sustain organizing committee. We promise to have a one-month response time for all submissions.
 
 The funds available have neither a lower nor an upper limit. All submissions are considered anonymously. 
-

--- a/_posts/SustainOSS-Organizing-Committee.md
+++ b/_posts/SustainOSS-Organizing-Committee.md
@@ -1,17 +1,17 @@
 # SustainOSS Organizing Committee – Sustain Workshops and Funding Applications
+
 ## Purpose:
 
 This document recognizes that current fund applications for workshops at Sustain are organized through exclusive, private networks connected to the Sustain organizer committee. By outlining, publicizing, and sharing this process, we hope to make a more inclusive community. 
 
-
 ## Proposal:
-
 
 The [SustainOSS](https://sustainoss.org/about/) (henceforth Sustain) organizing committee meets every couple of weeks to discuss organizational matters. Part of this involves planning for the next **Sustain Summit - most likely, as of this writing, in March 2023.** 
 
 The Sustain Summit is normally a one-day event which is held at a single venue, normally in a single room, with occasional breakout rooms as part of that process. Funds go towards photographers, catering, venue costs, comms, and travel expenses for bursaries. Funds can also go towards individual projects hosted at the session, and to their individual needs; they can also go towards ancillary events at Sustain, like workshops, which focus on some more specific aspect of software sustainability. 
 
 ## Application details: 
+
 In order to propose that SustainOSS funds are used for your workshop, we encourage you to use the following [form](https://forms.gle/Q9LsQwwD7tuk1hz16), which goes to the Sustain organizing committee. We promise to have a one-month response time for all submissions.
 
 The funds available have neither a lower nor an upper limit. All submissions are considered anonymously. 


### PR DESCRIPTION
The purpose of this proposal is for those who wish to host a workshop at sustain but need funding. This would be displayed on the sustain website as well as social media. 

<a href="https://gitpod.io/#https://github.com/sustainers/website/pull/339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

