### PR TITLE
Create best-practices page

### DIFF
--- a/about/best-practices.md
+++ b/about/best-practices.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: "Best Practices"
+slug: best-practices
+---
+
+<div class="container about">
+  <div class="row justify-content-center">
+    <div class="col-md-10">
+      <h2 class="text-center mb-4 tealdark">Best Practices</h2>
+
+      <p>Sustain is, at its ❤️, a group of people who work together to figure out how we can sustainably improve the open source ecosystem. While we don't have strict rules - we're a community, not a company! - we do have some best practices, which, over time, have grown to make it easier for us to work with each other and with new members.</p>
+
+      <p>This list is not exhaustive! But it is an attempt at showing newcomers how they can best engage, and for showing how we, as the long-standing members of Sustain, have managed to work together easily.</p>
+
+      <p>Not seeing something on this list? Add it! You can open a Pull Request at <a href="https://github.com/sustainers/website">the website repo</a>.</p>
+
+      <ul>
+        <li>We listen more than we speak. If we're talking a lot, we're probably missing something.</li>
+        <li>We accept that we can always improve, without shaming or blaming anyone, including ourselves.</li>
+        <li>We do not merge PRs without review. If someone opens a PR on the website, they wait for someone else to merge it.</li>
+      </ul>
+
+      </div>
+  </div>
+</div>

--- a/about/index.md
+++ b/about/index.md
@@ -87,6 +87,8 @@ slug: about
     <p>Also, we are <a href="https://validator.w3.org/check/referer" data-proofer-ignore>HTML5</a> valid and try to be
     <a class="text-decoration-none" href="https://www.w3.org/WAI/WCAG2AA-Conformance">WCAG2AA</a> compliant.</p>
 
+    <p>As well, we keep <a href="/about/best-practices">a list of best practices</a> for organisation. Take a look!</p>
+
   </div>
 </div>
 </div>


### PR DESCRIPTION
I have created a new page for best practices. I have also moved about from `about.md` to `about/index.md`, which means that we can have new pages listed under `about/` on the website.

No other structural changes!

<a href="https://gitpod.io/#https://github.com/sustainers/website/pull/342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

